### PR TITLE
[SYM-4202] Apply tags to generated AWS IAM policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Terraform
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+*.tfvars
+
+
+# IDE
+.idea/

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,8 @@ resource "aws_iam_policy" "assume_roles" {
     }]
     Version = "2012-10-17"
   })
+
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "extra_policy_attachments" {


### PR DESCRIPTION
Addresses Issue #1 
- Adds the tags specified by `var.tags` to the policies generated by the module.
![Screen Shot 2022-10-07 at 12 11 12 PM](https://user-images.githubusercontent.com/10479740/194600076-0878e6d9-6805-4cf6-b1a5-9fd410333a31.png)
