### PR TITLE
[SYM-4204] Allow the Runtime IAM role to assume itself

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,12 +20,19 @@ resource "aws_iam_role" "this" {
         Action = "sts:AssumeRole"
         Effect = "Allow"
         Principal = {
-          AWS = concat(var.sym_account_ids, ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.role_name}"])
+          AWS = var.sym_account_ids
         }
         Condition = {
           StringEquals = {
             "sts:ExternalId" = local.external_id
           }
+        }
+      },
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/sym/${local.role_name}"]
         }
       }
     ]

--- a/main.tf
+++ b/main.tf
@@ -5,27 +5,30 @@ locals {
   target_resources = [for acct in local.target_accts : "arn:aws:iam::${acct}:role/sym/*"]
 
   external_id = trimspace(var.custom_external_id) == "" ? random_uuid.external_id.result : var.custom_external_id
+  role_name = "SymRuntime${title(var.environment)}"
 }
 
 resource "random_uuid" "external_id" {}
 
 resource "aws_iam_role" "this" {
-  name = "SymRuntime${title(var.environment)}"
+  name = local.role_name
   path = "/sym/"
 
   assume_role_policy = jsonencode({
-    Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
-      Principal = {
-        AWS = var.sym_account_ids
-      }
-      Condition = {
-        StringEquals = {
-          "sts:ExternalId" = local.external_id
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = concat(var.sym_account_ids, ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.role_name}"])
+        }
+        Condition = {
+          StringEquals = {
+            "sts:ExternalId" = local.external_id
+          }
         }
       }
-    }]
+    ]
     Version = "2012-10-17"
   })
 
@@ -39,7 +42,7 @@ resource "aws_iam_role_policy_attachment" "assume_roles_attach" {
 
 # Allow the runtime to assume roles in the /sym/ path in safelisted accounts
 resource "aws_iam_policy" "assume_roles" {
-  name = "SymRuntime${title(var.environment)}"
+  name = local.role_name
   path = "/sym/"
 
   description = "Base permissions for the Sym runtime"


### PR DESCRIPTION
Due to [recent changes by AWS](https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/), this behavior must be explicitly defined in the policy. 

While it's undesirable for Sym to need self-referential IAM role assumption permission long term, this will unblock any new users for now.
