### PR TITLE
[SYM-4763] Runtime Connector v2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ module "runtime_connector" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.65.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
-| <a name="provider_sym"></a> [sym](#provider\_sym) | 3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_sym"></a> [sym](#provider\_sym) | >= 2.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -24,34 +24,30 @@ module "runtime_connector" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_sym"></a> [sym](#requirement\_sym) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.65.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_sym"></a> [sym](#provider\_sym) | 3.0.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_aws_kinesis_data_stream"></a> [aws\_kinesis\_data\_stream](#module\_aws\_kinesis\_data\_stream) | symopsio/kinesis-data-stream-addon/aws | >= 1.0.0 |
-| <a name="module_aws_kinesis_firehose"></a> [aws\_kinesis\_firehose](#module\_aws\_kinesis\_firehose) | symopsio/kinesis-firehose-addon/aws | >= 1.0.0 |
-| <a name="module_aws_secretsmgr"></a> [aws\_secretsmgr](#module\_aws\_secretsmgr) | symopsio/secretsmgr-addon/aws | >= 1.0.0 |
+No modules.
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_iam_policy.assume_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.assume_roles_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.aws_kinesis_data_stream_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.aws_kinesis_firehose_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.aws_secretsmgr_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.extra_policy_attachments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role.sym_runtime_connector_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.attach_assume_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [random_uuid.external_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
+| [sym_integration.runtime_context](https://registry.terraform.io/providers/symopsio/sym/latest/docs/resources/integration) | resource |
+| [sym_runtime.this](https://registry.terraform.io/providers/symopsio/sym/latest/docs/resources/runtime) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
@@ -59,19 +55,15 @@ module "runtime_connector" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_id_safelist"></a> [account\_id\_safelist](#input\_account\_id\_safelist) | List of addtional AWS account ids (beyond the current AWS account) that the runtime can assume roles in. | `list(string)` | `[]` | no |
-| <a name="input_addon_params"></a> [addon\_params](#input\_addon\_params) | Additional parameters for selected addons | `map(map(any))` | `{}` | no |
-| <a name="input_addons"></a> [addons](#input\_addons) | List of Sym addon permissions for the runtime connector role. Addons give the runtime permissions to work with other resources without assuming another AWS role. | `list(string)` | `[]` | no |
-| <a name="input_custom_external_id"></a> [custom\_external\_id](#input\_custom\_external\_id) | The external ID to use for AWS assume role validation. If unspecified, the connector generates an external ID and the Sym platform ensures it is unique. | `string` | `""` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | An environment qualifier for the resources this module creates, to support a Terraform SDLC. | `string` | n/a | yes |
-| <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | Map of logical identifiers to additional IAM Managed Policy ARNs to add to the runtime connector role. The identifiers are only used for managing Terraform state. | `map(string)` | `{}` | no |
-| <a name="input_sym_account_ids"></a> [sym\_account\_ids](#input\_sym\_account\_ids) | List of account ids that can assume the runtime role. By default, only Sym production accounts can assume the runtime role. | `list(string)` | <pre>[<br>  "803477428605"<br>]</pre> | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags to apply to resources | `map(string)` | `{}` | no |
+| <a name="input_environment_name"></a> [environment\_name](#input\_environment\_name) | The unique name of the environment in which you are deploying this Sym Runtime Role. (e.g. staging, or prod) | `string` | n/a | yes |
+| <a name="input_sym_account_id"></a> [sym\_account\_id](#input\_sym\_account\_id) | The AWS account ID that can assume the Sym Runtime Role. Defaults to the Sym Production AWS account ID. | `string` | `"803477428605"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags to apply to the AWS resources | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_account_id"></a> [account\_id](#output\_account\_id) | The AWS account ID for this connector |
-| <a name="output_settings"></a> [settings](#output\_settings) | A map of settings to supply to a Sym Permission Context. |
+| <a name="output_sym_integration"></a> [sym\_integration](#output\_sym\_integration) | A [sym\_integration](https://registry.terraform.io/providers/symopsio/sym/latest/docs/resources/integration) resource that tells the Sym Runtime which AWS Role to assume to perform actions in your AWS account. For example, this can be used in sym\_runtime and sym\_secrets resources. |
+| <a name="output_sym_runtime"></a> [sym\_runtime](#output\_sym\_runtime) | A [sym\_runtime](https://registry.terraform.io/providers/symopsio/sym/latest/docs/resources/runtime) resource to be passed into your sym\_environment to enable the execution of AWS Strategies. |
+| <a name="output_sym_runtime_connector_role"></a> [sym\_runtime\_connector\_role](#output\_sym\_runtime\_connector\_role) | An [aws\_iam\_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) resource. This AWS IAM Role will be assumed by the Sym Runtime to execute operations in your AWS account. |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # runtime-connector
 
-The `runtime-connector` module provisions the IAM role that a Sym Runtime uses to execute a Flow.
+The `runtime-connector` module provisions the AWS IAM role that a Sym Runtime uses to execute a Flow.
 
-This `Connector` will provision a single IAM role for the Sym Runtime to use at execution time.
+By default, this Sym Runtime Role has permissions to assume additional roles that have a path that begins with `/sym/`,
+and only within a provided safelist of AWS accounts. The Runtime always includes the current AWS account in the safelist.
 
-By default, the Runtime only has permissions to assume roles that have a path that begins with `/sym/`, and only within a provided safelist of AWS accounts. The Runtime always includes the current AWS account in the safelist.
-
-The role created for the Runtime uses an [External ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html), a best practice for invoking cross-account roles. This module will generate an External ID for you, unless you configure the `custom_external_id` to override it.
+The role created for the Runtime uses an [External ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html), a best practice for invoking cross-account roles.
 
 ```hcl
 module "runtime_connector" {
   source  = "symopsio/runtime-connector/aws"
-  version = ">= 1.0.0"
+  version = ">= 2.0.0"
 
-  environment = "sandbox"
+  environment_name = "sandbox"
 }
 ```
 
@@ -55,6 +54,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_account_id_safelist"></a> [account\_id\_safelist](#input\_account\_id\_safelist) | List of additional AWS account IDs (beyond the current AWS account) that the Sym Runtime Role can assume roles in. (e.g. The SSO Management Account ID) | `list(string)` | `[]` | no |
 | <a name="input_environment_name"></a> [environment\_name](#input\_environment\_name) | The unique name of the environment in which you are deploying this Sym Runtime Role. (e.g. staging, or prod) | `string` | n/a | yes |
 | <a name="input_sym_account_id"></a> [sym\_account\_id](#input\_sym\_account\_id) | The AWS account ID that can assume the Sym Runtime Role. Defaults to the Sym Production AWS account ID. | `string` | `"803477428605"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags to apply to the AWS resources | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id_safelist"></a> [account\_id\_safelist](#input\_account\_id\_safelist) | List of additional AWS account IDs (beyond the current AWS account) that the Sym Runtime Role can assume roles in. (e.g. The SSO Management Account ID) | `list(string)` | `[]` | no |
-| <a name="input_environment_name"></a> [environment\_name](#input\_environment\_name) | The unique name of the environment in which you are deploying this Sym Runtime Role. (e.g. staging, or prod) | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | The unique name of the environment in which you are deploying this Sym Runtime Role. (e.g. staging, or prod) | `string` | n/a | yes |
 | <a name="input_sym_account_id"></a> [sym\_account\_id](#input\_sym\_account\_id) | The AWS account ID that can assume the Sym Runtime Role. Defaults to the Sym Production AWS account ID. | `string` | `"803477428605"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags to apply to the AWS resources | `map(string)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  role_name = "SymRuntime${title(var.environment_name)}"
+  role_name = "SymRuntime${title(var.environment)}"
 
   # Variables to generate a list of AWS IAM Roles that the Sym Runtime Role can assume.
   # The Sym Runtime Role can assume roles in the /sym/ path in the current AWS account and all accounts specified in the
@@ -86,7 +86,7 @@ resource "aws_iam_role_policy_attachment" "attach_assume_roles" {
 # An Integration that tells the Sym Runtime which AWS Role to assume to perform actions in your AWS account.
 resource "sym_integration" "runtime_context" {
   type = "permission_context"
-  name = "${var.environment_name}-runtime-context"
+  name = "${var.environment}-runtime-context"
 
   # This tells Sym which AWS account the IAM Role is in.
   # It is different from settings.external_id below, which is the AWS-specific external_id.
@@ -102,7 +102,7 @@ resource "sym_integration" "runtime_context" {
 }
 
 resource "sym_runtime" "this" {
-  name = var.environment_name
+  name = var.environment
 
   # Give the Sym Runtime the permissions defined by the runtime_context resource.
   context_id = sym_integration.runtime_context.id

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "aws_iam_policy" "assume_roles" {
   name = local.role_name
   path = "/sym/"
 
-  description = "These are base permissions required for the Sym Runtime to perform any actions in your AWS account. This policy allows the Sym Runtime to assume roles in the /sym/ path in safelisted accounts."
+  description = "These are base permissions required for the Sym Runtime to perform any actions in your AWS account. This policy allows the Sym Runtime to assume roles in the /sym/ path in the current AWS account."
   policy = jsonencode({
     Statement = [{
       Action   = "sts:AssumeRole"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  role_name  = "SymRuntime${title(var.environment_name)}"
+  role_name = "SymRuntime${title(var.environment_name)}"
 }
 
 # A data source to read the effective Account ID, User ID, and ARN in which Terraform is authorized.

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,20 +5,20 @@ output "sym_runtime_connector_role_arn" {
 
 output "sym_runtime_connector_role_name" {
   description = "The name of the AWS IAM Role to be assumed by the Sym Runtime to execute operations in your AWS account."
-  value = aws_iam_role.sym_runtime_connector_role.name
+  value       = aws_iam_role.sym_runtime_connector_role.name
 }
 
 output "sym_runtime_connector_role_external_id" {
   description = "The STS External ID that must be provided by Sym when the Sym Runtime assumes the AWS IAM Role."
-  value = random_uuid.external_id.result
+  value       = random_uuid.external_id.result
 }
 
 output "sym_integration_runtime_context_id" {
   description = "The ID of an Integration that tells the Sym Runtime which AWS Role to assume to perform actions in your AWS account. For example, this can be used in sym_runtime and sym_secrets resources."
-  value = sym_integration.runtime_context.id
+  value       = sym_integration.runtime_context.id
 }
 
 output "sym_runtime_id" {
   description = "The ID of a sym_runtime resource to be passed into your sym_environment to enable the execution of AWS Strategies."
-  value = sym_runtime.this.id
+  value       = sym_runtime.this.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "sym_runtime_connector_role" {
 
 output "sym_integration" {
   description = "A [sym_integration](https://registry.terraform.io/providers/symopsio/sym/latest/docs/resources/integration) resource that tells the Sym Runtime which AWS Role to assume to perform actions in your AWS account. For example, this can be used in sym_runtime and sym_secrets resources."
-  value       = sym_integration.runtime_context.id
+  value       = sym_integration.runtime_context
 }
 
 output "sym_runtime" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "sym_runtime_connector_role" {
   description = "An [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) resource. This AWS IAM Role will be assumed by the Sym Runtime to execute operations in your AWS account."
-  value = aws_iam_role.sym_runtime_connector_role
+  value       = aws_iam_role.sym_runtime_connector_role
 }
 
 output "sym_integration" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,17 +1,24 @@
-output "account_id" {
-  description = "The AWS account ID for this connector"
-  value       = data.aws_caller_identity.current.account_id
+output "sym_runtime_connector_role_arn" {
+  description = "The ARN of the AWS IAM Role that the Sym Runtime will assume to execute operations in your AWS account."
+  value       = aws_iam_role.sym_runtime_connector_role.arn
 }
 
-data "aws_region" "current" {}
+output "sym_runtime_connector_role_name" {
+  description = "The name of the AWS IAM Role to be assumed by the Sym Runtime to execute operations in your AWS account."
+  value = aws_iam_role.sym_runtime_connector_role.name
+}
 
-output "settings" {
-  description = "A map of settings to supply to a Sym Permission Context."
-  value = {
-    cloud       = "aws"
-    region      = data.aws_region.current.name
-    role_arn    = aws_iam_role.this.arn
-    external_id = local.external_id
-    account_id  = data.aws_caller_identity.current.account_id
-  }
+output "sym_runtime_connector_role_external_id" {
+  description = "The STS External ID that must be provided by Sym when the Sym Runtime assumes the AWS IAM Role."
+  value = random_uuid.external_id.result
+}
+
+output "sym_integration_runtime_context_id" {
+  description = "The ID of an Integration that tells the Sym Runtime which AWS Role to assume to perform actions in your AWS account. For example, this can be used in sym_runtime and sym_secrets resources."
+  value = sym_integration.runtime_context.id
+}
+
+output "sym_runtime_id" {
+  description = "The ID of a sym_runtime resource to be passed into your sym_environment to enable the execution of AWS Strategies."
+  value = sym_runtime.this.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,14 @@
-output "sym_runtime_connector_role_arn" {
-  description = "The ARN of the AWS IAM Role that the Sym Runtime will assume to execute operations in your AWS account."
-  value       = aws_iam_role.sym_runtime_connector_role.arn
+output "sym_runtime_connector_role" {
+  description = "An [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) resource. This AWS IAM Role will be assumed by the Sym Runtime to execute operations in your AWS account."
+  value = aws_iam_role.sym_runtime_connector_role
 }
 
-output "sym_runtime_connector_role_name" {
-  description = "The name of the AWS IAM Role to be assumed by the Sym Runtime to execute operations in your AWS account."
-  value       = aws_iam_role.sym_runtime_connector_role.name
-}
-
-output "sym_runtime_connector_role_external_id" {
-  description = "The STS External ID that must be provided by Sym when the Sym Runtime assumes the AWS IAM Role."
-  value       = random_uuid.external_id.result
-}
-
-output "sym_integration_runtime_context_id" {
-  description = "The ID of an Integration that tells the Sym Runtime which AWS Role to assume to perform actions in your AWS account. For example, this can be used in sym_runtime and sym_secrets resources."
+output "sym_integration" {
+  description = "A [sym_integration](https://registry.terraform.io/providers/symopsio/sym/latest/docs/resources/integration) resource that tells the Sym Runtime which AWS Role to assume to perform actions in your AWS account. For example, this can be used in sym_runtime and sym_secrets resources."
   value       = sym_integration.runtime_context.id
 }
 
-output "sym_runtime_id" {
-  description = "The ID of a sym_runtime resource to be passed into your sym_environment to enable the execution of AWS Strategies."
-  value       = sym_runtime.this.id
+output "sym_runtime" {
+  description = "A [sym_runtime](https://registry.terraform.io/providers/symopsio/sym/latest/docs/resources/runtime) resource to be passed into your sym_environment to enable the execution of AWS Strategies."
+  value       = sym_runtime.this
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-variable "environment_name" {
+variable "environment" {
   description = "The unique name of the environment in which you are deploying this Sym Runtime Role. (e.g. staging, or prod)"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,3 +14,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "account_id_safelist" {
+  description = "List of additional AWS account IDs (beyond the current AWS account) that the Sym Runtime Role can assume roles in. (e.g. The SSO Management Account ID)"
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,51 +1,16 @@
-variable "account_id_safelist" {
-  description = "List of addtional AWS account ids (beyond the current AWS account) that the runtime can assume roles in."
-  type        = list(string)
-  default     = []
-}
-
-variable "addons" {
-  description = "List of Sym addon permissions for the runtime connector role. Addons give the runtime permissions to work with other resources without assuming another AWS role."
-  type        = list(string)
-  default     = []
-
-  validation {
-    condition     = length(setsubtract(var.addons, ["aws/secretsmgr", "aws/kinesis-firehose", "aws/kinesis-data-stream"])) == 0
-    error_message = "Unsupported addon value."
-  }
-}
-
-variable "custom_external_id" {
-  description = "The external ID to use for AWS assume role validation. If unspecified, the connector generates an external ID and the Sym platform ensures it is unique."
-  default     = ""
+variable "environment_name" {
+  description = "The unique name of the environment in which you are deploying this Sym Runtime Role. (e.g. staging, or prod)"
   type        = string
 }
 
-variable "environment" {
-  description = "An environment qualifier for the resources this module creates, to support a Terraform SDLC."
+variable "sym_account_id" {
+  description = "The AWS account ID that can assume the Sym Runtime Role. Defaults to the Sym Production AWS account ID."
   type        = string
-}
-
-variable "policy_arns" {
-  description = "Map of logical identifiers to additional IAM Managed Policy ARNs to add to the runtime connector role. The identifiers are only used for managing Terraform state."
-  type        = map(string)
-  default     = {}
-}
-
-variable "sym_account_ids" {
-  description = "List of account ids that can assume the runtime role. By default, only Sym production accounts can assume the runtime role."
-  type        = list(string)
-  default     = ["803477428605"]
+  default     = "803477428605"
 }
 
 variable "tags" {
-  description = "Additional tags to apply to resources"
+  description = "Additional tags to apply to the AWS resources"
   type        = map(string)
-  default     = {}
-}
-
-variable "addon_params" {
-  description = "Additional parameters for selected addons"
-  type        = map(map(any))
   default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     sym = {
       source  = "symopsio/sym"
-      version = "~> 2.0"
+      version = ">= 2.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.0"
     }
+    sym = {
+      source  = "symopsio/sym"
+      version = "~> 2.0"
+    }
   }
 }


### PR DESCRIPTION
# Summary
Modifies the module to follow our new atomicity conventions:
- Removes the add-ons, as those modules/resources should be specified separately
- Simplifies the inputs to only require the environment name
- Outputs the AWS IAM Role, sym_integration, and sym_runtime objects 

Inputs:
- environment_name: string
- tags: map(string), defaults to empty map
- sym_account_id: optional string

Outputs:
- sym_runtime_connector_role
- sym_integration
- sym_runtime

# Testing
Tested with the Okta Flow example in https://github.com/symopsio/examples/pull/60