### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ module "runtime_connector" {
   source  = "symopsio/runtime-connector/aws"
   version = ">= 2.0.0"
 
-  environment_name = "sandbox"
+  environment = "sandbox"
 }
 ```
 


### PR DESCRIPTION
# Summary
- Fixes the example declaration in the readme to use `environment` as the input, not `environment_name`
